### PR TITLE
Improve Sign In experience

### DIFF
--- a/app/assets/stylesheets/modern.scss
+++ b/app/assets/stylesheets/modern.scss
@@ -70,13 +70,14 @@ ul {
 
 .panel-body {
   width: 100%;
+  padding: 20px;
 }
 
 .pnl-footer {
   width: 100%;
   min-height: 40px;
   margin-bottom: 0;
-  padding: 40px 0px;
+  padding: 20px;
   .btn-link{
     color: $border-color;
     font-family: $main-font;
@@ -96,6 +97,7 @@ ul {
 .login-form {
   width: 80%;
   margin: 20px auto;
+  font-size: 16px;
 }
 
 .control-box {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,14 +3,17 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-  	if session[:user_id]
+    if session[:user_id]
   		@current_user ||= User.find(session[:user_id])
-  	end
+  	else
+      @current_user ||= nil
+    end
   end
+
   helper_method :current_user
 
   def authenticate_user
   	redirect_to login_path unless current_user
   end
-  
+
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,16 +1,21 @@
 class SessionsController < ApplicationController
 layout 'modern'
 
-	def new	 
+	def index
+		redirect_to companies_url if current_user
+		render "new" unless current_user
+	end
+
+	def new
 	end
 
 	def create
 		user = User.find_by_email(params[:email])
 		if user && user.authenticate(params[:password])
-			session[:user_id]= user.id 
+			session[:user_id]= user.id
 			redirect_to companies_url, notice: "Log in successful!"
 		else
-			flash.now.alert = "Invalid email or password!"
+			flash.now.alert = "The email or password you entered is invalid. Please try again"
 			render "new"
 		end
 	end

--- a/app/views/layouts/modern.html.erb
+++ b/app/views/layouts/modern.html.erb
@@ -20,11 +20,12 @@
           <span>LOYAL BANK </span>
           <i class="fa fa-sign-in" aria-hidden="true"></i>
         </div>
+        <% unless controller_name == 'sessions' %>
         <ul class="header-nav">
           <li class="header-nav-item active">AUTHORIZE</li>
           <li class="header-nav-item">COMPANIES</li>
         </ul>
-        
+        <% end %>
       </div>
     </div>
   </div>
@@ -38,11 +39,3 @@
   </div>
 </body>
 </html>
-
-
-
-
-
-
-
-

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,10 +1,10 @@
 <%= form_tag sessions_path, class: "form-horizontal" do %>
 <div class="panel-header">
 	<center>
-		<h3>Hello!</h3>
+		<h3>Sign In</h3>
 	</center>
 </div>
-<div class="panel-body">            
+<div class="panel-body">
 	<div class="login-form">
 
 		<div class="control-box">
@@ -25,9 +25,11 @@
 </div>
 <div class="pnl-footer">
 	<center>
+		<% if flash[:alert] %>
+	     <div class="alert alert-danger"><%= flash[:alert] %></div>
+	   <% end %>
 		<i class="fa fa-sign-in fa-2x signin-icon" aria-hidden="true"></i>
 		<%= submit_tag "Sign In", class: "btn-link" %>
 	</center>
 </div>
 <% end %>
-


### PR DESCRIPTION
This PR does the following
   *  Update login page title from `hello` to `Sign In`
   *  Use a consistent padding for panel header, body and footer
   *  Display error message when username/password is incorrect
   *  Don't show navigation menus on sign in page
   * Ensure '/sessions/' path renders the sign in page if user is not logged in or redirects to companies page if user is already logged in